### PR TITLE
Update sebastian/diff and phpunit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
   "require": {
     "php": "~5.5|^7.0",
     "behat/gherkin": "^4.4",
-    "sebastian/diff": "~1.2",
-    "symfony/console": "~2.0|^3.0|^4.0",
-    "symfony/finder": "~2.0|^3.0|^4.0"
+    "sebastian/diff": "^3.0|^4.0",
+    "symfony/console": "^2.0|^3.0|^4.0",
+    "symfony/finder": "^2.0|^3.0|^4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.0"
+    "phpunit/phpunit": "^7.0"
   },
   "bin": [
     "bin/kawaii"

--- a/src/Command/CheckGherkinCodeStyle.php
+++ b/src/Command/CheckGherkinCodeStyle.php
@@ -28,6 +28,7 @@ use KawaiiGherkin\Formatter\Scenario;
 use KawaiiGherkin\Formatter\Step;
 use KawaiiGherkin\Formatter\Tags;
 use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -117,7 +118,8 @@ final class CheckGherkinCodeStyle extends Command
                     define('FAILED', true);
                 }
 
-                $diff = new Differ("--- Original\n+++ Expected\n", false);
+                $outputBuilder = new UnifiedDiffOutputBuilder("--- Original\n+++ Expected\n", false);
+                $diff = new Differ($outputBuilder);
 
                 $output->writeln('<error>Wrong style: ' . $file->getRealPath() . '</error>');
                 $output->writeln($diff->diff($contentWithoutComments, $formatted));

--- a/tests/Command/CheckGherkinCodeStyleTest.php
+++ b/tests/Command/CheckGherkinCodeStyleTest.php
@@ -24,6 +24,7 @@ use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Gherkin\Parser;
 use KawaiiGherkin\Command\CheckGherkinCodeStyle;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -35,11 +36,10 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @group Coverage
  * @license MIT
  */
-final class CheckGherkinCodeStyleTest extends \PHPUnit_Framework_TestCase
+final class CheckGherkinCodeStyleTest extends TestCase
 {
     public function testShouldReturnOkIfThereIsNoFilesFound()
     {
-        $kernel = $this->getMock(\stdClass::class);
         /* @var \Behat\Gherkin\Parser|\PHPUnit_Framework_MockObject_MockObject $parser */
         $parser = $this->getMockBuilder(Parser::class)
             ->disableOriginalConstructor()
@@ -48,7 +48,7 @@ final class CheckGherkinCodeStyleTest extends \PHPUnit_Framework_TestCase
         $parser->expects(self::exactly(0))
             ->method('parse');
 
-        $application = new Application($kernel);
+        $application = new Application('test');
         $application->add(new CheckGherkinCodeStyle(null, $parser));
 
         $command       = $application->find('gherkin:check');
@@ -64,8 +64,6 @@ final class CheckGherkinCodeStyleTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldReturnErrorIfThereIsFilesWithWrongStyle()
     {
-        $kernel = $this->getMock(\stdClass::class);
-
         /* @var \Behat\Gherkin\Parser|\PHPUnit_Framework_MockObject_MockObject $parser */
         $parser = $this->getMockBuilder(Parser::class)
             ->disableOriginalConstructor()
@@ -124,7 +122,7 @@ final class CheckGherkinCodeStyleTest extends \PHPUnit_Framework_TestCase
             ->method('parse')
             ->willReturn($feature);
 
-        $application = new Application($kernel);
+        $application = new Application('test');
         $application->add(new CheckGherkinCodeStyle(null, $parser));
 
         $command       = $application->find('gherkin:check');

--- a/tests/FeatureResolveTest.php
+++ b/tests/FeatureResolveTest.php
@@ -3,8 +3,9 @@
 namespace KawaiiGherkinTest;
 
 use KawaiiGherkin\FeatureResolve;
+use PHPUnit\Framework\TestCase;
 
-final class FeatureResolveTest extends \PHPUnit_Framework_TestCase
+final class FeatureResolveTest extends TestCase
 {
     /**
      * @dataProvider unExistsDirectory

--- a/tests/Formatter/BackgroundTest.php
+++ b/tests/Formatter/BackgroundTest.php
@@ -22,6 +22,7 @@ use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use KawaiiGherkin\Formatter\Background;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**
@@ -32,7 +33,7 @@ use Prophecy\Argument;
  * @group  Coverage
  * @license MIT
  */
-final class BackgroundTest extends \PHPUnit_Framework_TestCase
+final class BackgroundTest extends TestCase
 {
     /**
      * @var Background

--- a/tests/Formatter/ExampleTest.php
+++ b/tests/Formatter/ExampleTest.php
@@ -21,6 +21,7 @@ namespace KawaiiGherkinTest\Formatter;
 use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\OutlineNode;
 use KawaiiGherkin\Formatter\Example;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \KawaiiGherkin\Formatter\Example}
@@ -30,7 +31,7 @@ use KawaiiGherkin\Formatter\Example;
  * @group Coverage
  * @license MIT
  */
-final class ExampleTest extends \PHPUnit_Framework_TestCase
+final class ExampleTest extends TestCase
 {
     /**
      * @var Example

--- a/tests/Formatter/FeatureDescriptionTest.php
+++ b/tests/Formatter/FeatureDescriptionTest.php
@@ -20,6 +20,7 @@ namespace KawaiiGherkinTest\Formatter;
 
 use Behat\Gherkin\Node\FeatureNode;
 use KawaiiGherkin\Formatter\FeatureDescription;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \KawaiiGherkin\Formatter\FeatureDescription}
@@ -29,7 +30,7 @@ use KawaiiGherkin\Formatter\FeatureDescription;
  * @group Coverage
  * @license MIT
  */
-final class FeatureDescriptionTest extends \PHPUnit_Framework_TestCase
+final class FeatureDescriptionTest extends TestCase
 {
     /**
      * @var FeatureDescription

--- a/tests/Formatter/ScenarioTest.php
+++ b/tests/Formatter/ScenarioTest.php
@@ -24,6 +24,7 @@ use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use KawaiiGherkin\Formatter\Scenario;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \KawaiiGherkin\Formatter\Scenario}
@@ -33,7 +34,7 @@ use KawaiiGherkin\Formatter\Scenario;
  * @group Coverage
  * @license MIT
 */
-final class ScenarioTest extends \PHPUnit_Framework_TestCase
+final class ScenarioTest extends TestCase
 {
     /**
      * @var Scenario

--- a/tests/Formatter/StepTest.php
+++ b/tests/Formatter/StepTest.php
@@ -23,6 +23,7 @@ use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use KawaiiGherkin\Formatter\Step;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \KawaiiGherkin\Formatter\Step}
@@ -32,7 +33,7 @@ use KawaiiGherkin\Formatter\Step;
  * @group Coverage
  * @license MIT
  */
-final class StepTest extends \PHPUnit_Framework_TestCase
+final class StepTest extends TestCase
 {
     /**
      * @var Step

--- a/tests/Formatter/TagsTest.php
+++ b/tests/Formatter/TagsTest.php
@@ -19,6 +19,7 @@
 namespace KawaiiGherkinTest\Formatter;
 
 use KawaiiGherkin\Formatter\Tags;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \KawaiiGherkin\Formatter\Tags}
@@ -28,7 +29,7 @@ use KawaiiGherkin\Formatter\Tags;
  * @group Coverage
  * @license MIT
  */
-final class TagsTest extends \PHPUnit_Framework_TestCase
+final class TagsTest extends TestCase
 {
     /**
      * @var Tags

--- a/tests/functional/check-a-specific-language.phpt
+++ b/tests/functional/check-a-specific-language.phpt
@@ -15,6 +15,16 @@ Finding files on tests/assets/language.feature
 Wrong style: %A/tests/assets/language.feature
 --- Original
 +++ Expected
+@@ @@
 +# language: fr
+ @users @another-feature @another-tag
+ Fonctionnalité: User registration
+     In order to order products
+@@ @@
+ 
+     Contexte: Nice Background
+         Soit store has default configuration
 -          Et there are following users:
 +        Et there are following users:
+             | email       | password             |
+             | bar@bar.com | foo1sasdasdasdadsasd |

--- a/tests/functional/check-file-can-format-table-using-unix-line-endings.phpt
+++ b/tests/functional/check-file-can-format-table-using-unix-line-endings.phpt
@@ -14,9 +14,12 @@ Finding files on tests/assets/issue-3.feature
 Wrong style: %A/tests/assets/issue-3.feature
 --- Original
 +++ Expected
+@@ @@
+ Feature: Test Welcome page
 -  Scenario Outline:
 -      When I navigate in <locale> language
 -      Then I should see "<message>"
+ 
 -      Examples:
 -        | locale | message                           |
 -        | fr     | Bienvenue %USERNAME%.             |

--- a/tests/functional/check-file-with-left-parameter.phpt
+++ b/tests/functional/check-file-with-left-parameter.phpt
@@ -14,10 +14,16 @@ Finding files on tests/assets/left-aligned.feature
 Wrong style: %A/tests/assets/left-aligned.feature
 --- Original
 +++ Expected
+@@ @@
+     @javascript @bug-features
+     Scenario: Successfully creating account in store
+         Given I am on the store homepage
 -        And I follow "Register"
 -        When I fill in the following:
 +          And I follow "Register"
 +         When I fill in the following:
+             | First name | John |
+             | Last name  | Doe  |
 -        And I press "Register"
 -        Then I should see "Welcome"
 -        And I should see "Logout"

--- a/tests/functional/check-gherkin-default-left.phpt
+++ b/tests/functional/check-gherkin-default-left.phpt
@@ -14,5 +14,11 @@ Finding files on tests/assets/left-aligned.feature
 Wrong style: %A/tests/assets/left-aligned.feature
 --- Original
 +++ Expected
+@@ @@
+ 
+     Background: Nice Background
+         Given store has default configuration
 -          And there are following users:
 +        And there are following users:
+             | email       | password             |
+             | bar@bar.com | foo1sasdasdasdadsasd |

--- a/tests/functional/check-style-by-file.phpt
+++ b/tests/functional/check-style-by-file.phpt
@@ -15,5 +15,11 @@ Finding files on tests/assets/left-aligned.feature
 Wrong style: %A/tests/assets/left-aligned.feature
 --- Original
 +++ Expected
+@@ @@
+ 
+     Background: Nice Background
+         Given store has default configuration
 -          And there are following users:
 +        And there are following users:
+             | email       | password             |
+             | bar@bar.com | foo1sasdasdasdadsasd |

--- a/tests/functional/init.php
+++ b/tests/functional/init.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\Assert;
+
 require  __DIR__ . '/../../vendor/autoload.php';
 
 /**
@@ -8,7 +10,7 @@ require  __DIR__ . '/../../vendor/autoload.php';
 $kawaiiGherkinCheck = function ($params) {
 
     if (!is_string($params)) {
-        PHPUnit_Framework_Assert::markTestSkipped(
+        Assert::markTestSkipped(
             sprintf(
                 '$param was expected to be a "string", "%s" given.',
                 gettype($params)


### PR DESCRIPTION
This updates the `sebastian/diff` dependency version so that the tool can be pulled in via composer when using a PHPUnit version > v4